### PR TITLE
update names, add readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
 # redux-helpers
-Small helper methods or mixins to help integrating Redux with a web-components app
+Small helper methods or mixins to help integrating Redux with a web-components app,
+and reduce the boilerplate you might have to write. There are many different
+ways in which you could write these helpers; use these if you want a simple
+starting point.
+
+## `connect-mixin.js`
+This is a JavaScript mixin that you can add to a Custom Element base class
+to automatically connect to a Redux store. It requires you to implement a
+`stateChanged` method, which is called every time the store state is updated.
+
+Example (in an element):
+```js
+import { connect } from '../node_modules/@polymer/redux-helpers/connect-mixin.js';
+
+class MyElement extends connect(store)(HTMLElement) {
+  // ...
+
+  stateChanged(state) {
+    this.count = state.data.count;
+  }
+}
+```
+
+## `router.js`
+This is a basic router that calls a callback whenever the location is updated,
+so that you can store that in the state.
+
+Example (in your top level element or document):
+```js
+import { installRouter } from '../node_modules/@polymer/redux-helpers/router.js';
+import { navigate } from '../actions/app.js';
+
+installRouter(() => store.dispatch(navigate(window.location)));
+```
+
+## `lazy-reducer-enhancer.js`
+A Redux store enhancer that lets you lazy-install reducers after the store
+has booted up. Use this if your application lazy-loads routes that are connected
+to a Redux store.
+
+Example (in your store code):
+```js
+import lazyReducerEnhancer from '../node_modules/@polymer/redux-helpers/lazy-reducer-enhancer.js';
+import someReducer from './reducers/someReducer.js';
+
+export const store = createStore(
+  (state, action) => state,
+  compose(lazyReducerEnhancer(combineReducers), applyMiddleware(thunk))
+);
+// An initial, lazy-loaded reducer. Use this for any other lazy reducers in elements as well.
+store.addReducers({
+  someReducer
+});
+```

--- a/connect-mixin.js
+++ b/connect-mixin.js
@@ -29,10 +29,16 @@ export const connect = (store) => (baseElement) => class extends baseElement {
     // Connect the element to the store.
     this.__storeUnsubscribe = store.subscribe(() => this.stateChanged(store.getState()));
     this.stateChanged(store.getState());
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
   }
 
   disconnectedCallback() {
     this.__storeUnsubscribe();
+    if (super.connectedCallback) {
+      super.disconnectedCallback();
+    }
   }
 
   // This is called every time something is updated in the store.

--- a/connect-mixin.js
+++ b/connect-mixin.js
@@ -18,24 +18,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   class MyElement extends connect(store)(HTMLElement) {
     // ...
 
-    update(state) {
+    stateChanged(state) {
       this.count = state.data.count;
     }
   }
 */
 
 export const connect = (store) => (baseElement) => class extends baseElement {
-  constructor() {
-    super();
-
+  connectedCallback() {
     // Connect the element to the store.
-    store.subscribe(() => this.update(store.getState()));
-    this.update(store.getState());
+    this.__storeUnsubscribe = store.subscribe(() => this.stateChanged(store.getState()));
+    this.stateChanged(store.getState());
   }
 
+  disconnectedCallback() {
+    this.__storeUnsubscribe();
+  }
 
   // This is called every time something is updated in the store.
-  update(state) {
-    throw new Error('update() not implemented', this);
+  stateChanged(state) {
+    throw new Error('stateChanged() not implemented', this);
   }
 };

--- a/connect-mixin.js
+++ b/connect-mixin.js
@@ -36,7 +36,8 @@ export const connect = (store) => (baseElement) => class extends baseElement {
 
   disconnectedCallback() {
     this.__storeUnsubscribe();
-    if (super.connectedCallback) {
+    
+    if (super.disconnectedCallback) {
       super.disconnectedCallback();
     }
   }

--- a/demo/components/my-app.js
+++ b/demo/components/my-app.js
@@ -76,7 +76,7 @@ class MyApp extends connect(store)(HTMLElement) {
     installRouter(() => store.dispatch(navigate(window.location)));
   }
 
-  update(state) {
+  stateChanged(state) {
     // The store boots up before we have stamped the template.
     if (!this._ready) {
       return;

--- a/demo/store.js
+++ b/demo/store.js
@@ -14,7 +14,7 @@ import createStore from '../node_modules/@0xcda7a/redux-es6/es/createStore.js';
 import origCompose from '../node_modules/@0xcda7a/redux-es6/es/compose.js';
 import combineReducers from '../node_modules/@0xcda7a/redux-es6/es/combineReducers.js';
 
-import { lazyReducerEnhancer } from '../lazyReducerEnhancer.js'
+import { lazyReducerEnhancer } from '../lazy-reducer-enhancer.js'
 const compose = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || origCompose;
 
 export const store = createStore(

--- a/lazy-reducer-enhancer.js
+++ b/lazy-reducer-enhancer.js
@@ -15,7 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Sample use (where you define your redux store, in store.js):
 
-  import lazyReducerEnhancer from '../node_modules/@webcomponents/redux-helpers/lazyReducerEnhancer.js';
+  import lazyReducerEnhancer from '../node_modules/@polymer/redux-helpers/lazy-reducer-enhancer.js';
   import someReducer from './reducers/someReducer.js';
 
   export const store = createStore(

--- a/router.js
+++ b/router.js
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Basic router that calls a callback whenever the location is updated.
 
   Sample use:
-  import { installRouter } from '../node_modules/@webcomponents/redux-helpers/router.js';
+  import { installRouter } from '../node_modules/@polymer/redux-helpers/router.js';
   import { navigate } from '../actions/app.js';
 
   // If you don’t have any other work to do other than dispatching an action,


### PR DESCRIPTION
Bunch of changes, all smooshed in one:
- moves the connection code from `constructor` (which is way too early) to `connectedCallback`. I think it tries to unsubscribe from the store in `disconnectedCallback` but I won't lie: I didn't test it.
- renames `update` (too general) to `stateChanged` (still pretty general but hopefully less so)
- since you already have to change your code because of that function name, i also renamed `lazyReducerEnhancer` to kebab case because `connect-mixin` had a dash and I couldn't deal 
- added words to the readme. Words are nice.